### PR TITLE
fix wrangle gets called always issue

### DIFF
--- a/lib/phototrim.rb
+++ b/lib/phototrim.rb
@@ -15,7 +15,7 @@ class Phototrimmer
 
   def main
     system("mkdir -p #{@dest}")
-    File.directory? @src ? wrangle : trim
+    File.directory?(@src)? wrangle : trim
   end
 
   def wrangle


### PR DESCRIPTION
This line makes wrangle function to always be called instead of trim when `@src` is a file.
Specifying it like that makes it work correctly :)
